### PR TITLE
Fix KelasController show method misuse

### DIFF
--- a/app/Http/Controllers/admin/KelasController.php
+++ b/app/Http/Controllers/admin/KelasController.php
@@ -72,9 +72,7 @@ class KelasController extends Controller
      */
     public function show(Kelas $kelas)
     {
-        $detailKelas = Kelas::find($kelas);
-        return view('admin.kelas.show', compact('detailKelas'));
-
+        return view('admin.kelas.show', ['detailKelas' => $kelas]);
     }
 
     /**

--- a/tests/Unit/AdminKelasControllerTest.php
+++ b/tests/Unit/AdminKelasControllerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Http\Controllers\admin\KelasController;
+use App\Kelas;
+
+class AdminKelasControllerTest extends TestCase
+{
+    public function test_show_uses_passed_model_in_view()
+    {
+        $controller = new KelasController();
+        $kelas = new Kelas(['id' => 1, 'nama_kelas' => 'Test']);
+
+        $view = $controller->show($kelas);
+
+        $this->assertEquals('admin.kelas.show', $view->name());
+        $this->assertSame($kelas, $view->getData()['detailKelas']);
+    }
+}


### PR DESCRIPTION
## Summary
- fix admin KelasController show method to use provided model instead of calling find
- add unit test for KelasController show method

## Testing
- `vendor/bin/phpunit` *(fails: Cannot acquire reference to $GLOBALS)*

------
https://chatgpt.com/codex/tasks/task_e_6896d4b99ae88323bf5ca5db6e999125